### PR TITLE
Add LoadingTransportEvent to include occurrence date for delivery

### DIFF
--- a/src/Xml/Templates/despatch2022.xml.twig
+++ b/src/Xml/Templates/despatch2022.xml.twig
@@ -128,6 +128,11 @@
 				</cac:PartyLegalEntity>
 			</cac:CarrierParty>
             {% endif %}
+			{% if envio.fecEntregaBienes %}
+            <cac:LoadingTransportEvent>
+                <cbc:OccurrenceDate>{{ doc.fecEntregaBienes|date('Y-m-d') }}</cbc:OccurrenceDate>
+            </cac:LoadingTransportEvent>
+			{% endif %}
 			{% for chofer in envio.choferes %}
 			<cac:DriverPerson>
 				<cbc:ID schemeID="{{ chofer.tipoDoc }}" schemeName="Documento de Identidad" schemeAgencyName="PE:SUNAT" schemeURI="urn:pe:gob:sunat:cpe:see:gem:catalogos:catalogo06">{{ chofer.nroDoc }}</cbc:ID>

--- a/src/Xml/Templates/despatch2022.xml.twig
+++ b/src/Xml/Templates/despatch2022.xml.twig
@@ -130,7 +130,7 @@
             {% endif %}
 			{% if envio.fecEntregaBienes %}
             <cac:LoadingTransportEvent>
-                <cbc:OccurrenceDate>{{ doc.fecEntregaBienes|date('Y-m-d') }}</cbc:OccurrenceDate>
+                <cbc:OccurrenceDate>{{ envio.fecEntregaBienes|date('Y-m-d') }}</cbc:OccurrenceDate>
             </cac:LoadingTransportEvent>
 			{% endif %}
 			{% for chofer in envio.choferes %}


### PR DESCRIPTION
This pull request introduces a conditional block in the `despatch2022.xml.twig` template to include a `LoadingTransportEvent` element when the `fecEntregaBienes` field is present. This ensures that the occurrence date of the goods delivery is only added to the XML when relevant data exists.

XML template enhancement:

* Added a conditional block to include the `<cac:LoadingTransportEvent>` element with an `<cbc:OccurrenceDate>` child, populated by `doc.fecEntregaBienes`, only when `envio.fecEntregaBienes` is set. This improves the accuracy and flexibility of the generated XML output.

<img width="700" height="512" alt="image" src="https://github.com/user-attachments/assets/4dd19e59-50ba-4ddf-a129-f10d51dd3921" />
