### PR TITLE
Fix LoadingTransportEvent to use correct occurrence date for delivery

### DIFF
--- a/src/Xml/Templates/despatch2022.xml.twig
+++ b/src/Xml/Templates/despatch2022.xml.twig
@@ -128,6 +128,11 @@
 				</cac:PartyLegalEntity>
 			</cac:CarrierParty>
             {% endif %}
+			{% if envio.fecEntregaBienes %}
+            <cac:LoadingTransportEvent>
+                <cbc:OccurrenceDate>{{ doc.fecEntregaBienes|date('Y-m-d') }}</cbc:OccurrenceDate>
+            </cac:LoadingTransportEvent>
+			{% endif %}
 			{% for chofer in envio.choferes %}
 			<cac:DriverPerson>
 				<cbc:ID schemeID="{{ chofer.tipoDoc }}" schemeName="Documento de Identidad" schemeAgencyName="PE:SUNAT" schemeURI="urn:pe:gob:sunat:cpe:see:gem:catalogos:catalogo06">{{ chofer.nroDoc }}</cbc:ID>

--- a/src/Xml/Templates/despatch2022.xml.twig
+++ b/src/Xml/Templates/despatch2022.xml.twig
@@ -130,7 +130,7 @@
             {% endif %}
 			{% if envio.fecEntregaBienes %}
             <cac:LoadingTransportEvent>
-                <cbc:OccurrenceDate>{{ doc.fecEntregaBienes|date('Y-m-d') }}</cbc:OccurrenceDate>
+                <cbc:OccurrenceDate>{{ envio.fecEntregaBienes|date('Y-m-d') }}</cbc:OccurrenceDate>
             </cac:LoadingTransportEvent>
 			{% endif %}
 			{% for chofer in envio.choferes %}


### PR DESCRIPTION
This pull request adds an enhancement to the `despatch2022.xml.twig` template by including a new XML element for the goods delivery date if it is provided in the input data.

Enhancement to XML template:

* Added a `<cac:LoadingTransportEvent>` element that outputs the `envio.fecEntregaBienes` date as `<cbc:OccurrenceDate>`, ensuring the delivery date is included in the XML when available.

<img width="700" height="512" alt="image" src="https://github.com/user-attachments/assets/1fb8f559-6aac-4963-8141-cedfa6d7ac3b" />
